### PR TITLE
[examplesim] replace init by _classpath

### DIFF
--- a/examplesim/src/examplesim/builder/sensors/extraservices.py
+++ b/examplesim/src/examplesim/builder/sensors/extraservices.py
@@ -1,7 +1,4 @@
 from morse.builder.creator import SensorCreator
 
 class ExtraServices(SensorCreator):
-    def __init__(self, name=None):
-        SensorCreator.__init__(self, name, \
-                               "examplesim.sensors.extraservices.ExtraServices",\
-                               "ExtraServices")
+    _classpath = "examplesim.sensors.extraservices.ExtraServices"


### PR DESCRIPTION
fixed builder bug in morse 1.3-190-gd7496 (latest git master)

...
    obj.game.physics_type = 'NO_COLLISION'
AttributeError: 'NoneType' object has no attribute 'game'
